### PR TITLE
Smooth out the metadata naming conventions

### DIFF
--- a/kubernetes/certbot-cron.yml
+++ b/kubernetes/certbot-cron.yml
@@ -33,7 +33,7 @@ spec:
   template:
     metadata:
       labels:
-        name: kong-certbot-agent
+        app: kong-certbot
     spec:
       containers:
       - name: runtime

--- a/kubernetes/certbot-cronjob.yml
+++ b/kubernetes/certbot-cronjob.yml
@@ -35,11 +35,10 @@ spec:
   jobTemplate:
     spec:
       template:
-
         # Matches selector on service above
         metadata:
-          app: kong-certbot
-
+          labels:
+            app: kong-certbot
         spec:
           restartPolicy: OnFailure
           containers:


### PR DESCRIPTION
I noticed that the service didn't connect to the deployment/cronjob because the metadata and selector weren't matching or the metadata was malformed.

I made all the labels match so that other people coming to this project won't wonder why their deployment/cronjob isn't reachable via the service.