### PR TITLE
Change service type to ClusterIP

### DIFF
--- a/kubernetes/certbot-cron.yml
+++ b/kubernetes/certbot-cron.yml
@@ -7,7 +7,7 @@ kind: Service
 metadata:
   name: kong-certbot-agent
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
   - name: certbot
     port: 80

--- a/kubernetes/certbot-cronjob.yml
+++ b/kubernetes/certbot-cronjob.yml
@@ -6,7 +6,7 @@ kind: Service
 metadata:
   name: kong-certbot-agent
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
   - name: certbot
     port: 80


### PR DESCRIPTION
This is actually a PR to ask a question: is there any practical reason these services were type 'NodePort'?

ClusterIP worked fine for me, and I can't think of a reason that either Let's Encrypt or a human would ever need to access this node via the NodePort.  Let me know if I'm missing something here.