### PR TITLE
Fixing SNIs in request

### DIFF
--- a/Command/UpdateCertificatesCommand.php
+++ b/Command/UpdateCertificatesCommand.php
@@ -103,7 +103,7 @@ class UpdateCertificatesCommand extends Command
                 'form_params' => [
                     'cert' => file_get_contents(sprintf('%s/fullchain.pem', $basePath)),
                     'key'  => file_get_contents(sprintf('%s/privkey.pem', $basePath)),
-                    'snis' => $domain,
+                    'snis[]' => $domain,
                 ],
             ];
 


### PR DESCRIPTION
Without this fix, SNIs do not get sent correctly to the Kong API.

Incidentally, you could probably not loop through each domain in the array, and just `implode(',', $domains)` here and pass them through all together.