### PR TITLE
Check for status code `400` in addition to `409` when updating Kong

### DIFF
--- a/Command/UpdateCertificatesCommand.php
+++ b/Command/UpdateCertificatesCommand.php
@@ -111,7 +111,7 @@ class UpdateCertificatesCommand extends Command
             try {
                 $guzzle->post(sprintf('%s/certificates', $kongAdminUri), $payload);
             } catch (ClientException $ex) {
-                if ($ex->getCode() !== 409) {
+                if (!in_array($ex->getCode(), [400, 409])) {
                     throw $ex;
                 }
 


### PR DESCRIPTION
Kong will send `400 Bad Request` when trying to update an existing cert/snis (schema violation) so we need to check for that as well.

Closes #14