### PR TITLE
Do not try running phpstan before composer install

### DIFF
--- a/concourse/tests.sh
+++ b/concourse/tests.sh
@@ -11,14 +11,15 @@ apt-get update
 apt-get install -y php-xdebug
 phpdismod xdebug
 
-# Static analysis
-vendor/bin/phpstan -v analyse -l 7 src -c phpstan.neon  && printf "\n ${bold}PHPStan:${normal} static analysis good\n\n" || exit 1
-
 # Store in here any test artifacts
 mkdir /tmp/reports/
 
-# Run unit tests
 composer -o install
+
+# Static analysis
+vendor/bin/phpstan -v analyse -l 7 src -c phpstan.neon  && printf "\n ${bold}PHPStan:${normal} static analysis good\n\n" || exit 1
+
+# Run unit tests
 vendor/bin/phpunit --testdox
 
 # Placeholder for extracting coverage metric


### PR DESCRIPTION
on other builds it worked because of vendor caching at CI