### PR TITLE
Track test coverage

### DIFF
--- a/concourse/pipeline-pull-requests.yaml
+++ b/concourse/pipeline-pull-requests.yaml
@@ -29,16 +29,18 @@ jobs:
 
       - task: run tests
         file: code/concourse/task-run-tests.yaml
-
         on_failure:
           put: code
           params:
             path: code
             status: failure
 
-      - task: codecov
-        -
       - put: code
         params:
           path: code
           status: success
+
+      - task: code coverage reports
+        params:
+          CODECOV_TOKEN: {{codecov-token}}
+        file: code/concourse/task-codecov.yaml

--- a/concourse/pipeline-pull-requests.yaml
+++ b/concourse/pipeline-pull-requests.yaml
@@ -36,6 +36,8 @@ jobs:
             path: code
             status: failure
 
+      - task: codecov
+        -
       - put: code
         params:
           path: code

--- a/concourse/task-codecov.yaml
+++ b/concourse/task-codecov.yaml
@@ -1,0 +1,24 @@
+platform: linux
+
+inputs:
+  - name: coverage-reports
+  - name: code
+
+image_resource:
+  type: docker-image
+  source:
+    repository: alpine
+    tag: latest
+
+params:
+  CODECOV_TOKEN:
+
+run:
+  path: /bin/sh
+  args:
+    - -xce
+    - |
+      apk add git bash curl --no-progress
+      curl -s https://codecov.io/bash > /tmp/codecov
+      cd code/
+      bash /tmp/codecov -f ../coverage-reports/phpunit/coverage.xml

--- a/concourse/task-run-tests.yaml
+++ b/concourse/task-run-tests.yaml
@@ -4,8 +4,10 @@ inputs:
   - name: code
 
 outputs:
-  - name: reports
-    path: /tmp/reports
+  - name: coverage-reports
+
+params:
+  CODECOV_TOKEN:
 
 image_resource:
   type: docker-image

--- a/concourse/tests.sh
+++ b/concourse/tests.sh
@@ -3,17 +3,16 @@
 # Ensure we exit with failure if anything here fails
 set -e
 
+INITIAL_FOLDER=`pwd`
+
 # cd into the codebase, as per CI source
 cd code
+mkdir reports
 
 # Install xdebug & disable
 apt-get update
 apt-get install -y php-xdebug
 phpdismod xdebug
-
-# Store in here any test artifacts
-mkdir /tmp/reports/
-ln -s /tmp/reports
 
 composer -o install
 
@@ -25,3 +24,9 @@ php -d zend_extension=xdebug.so vendor/bin/phpunit --testdox
 
 # Run mutation tests
 vendor/bin/infection --coverage=reports/infection --threads=2 -s --min-msi=95 --min-covered-msi=95
+
+# Go back to initial working dir to allow outputs to function
+cd ${INITIAL_FOLDER}
+
+# Copy reports to output
+cp code/reports/* coverage-reports/ -Rf

--- a/concourse/tests.sh
+++ b/concourse/tests.sh
@@ -13,6 +13,7 @@ phpdismod xdebug
 
 # Store in here any test artifacts
 mkdir /tmp/reports/
+ln -s /tmp/reports
 
 composer -o install
 
@@ -20,13 +21,7 @@ composer -o install
 vendor/bin/phpstan -v analyse -l 7 src -c phpstan.neon  && printf "\n ${bold}PHPStan:${normal} static analysis good\n\n" || exit 1
 
 # Run unit tests
-vendor/bin/phpunit --testdox
-
-# Placeholder for extracting coverage metric
-echo "fo" > /tmp/reports/phpunit
+php -d zend_extension=xdebug.so vendor/bin/phpunit --testdox
 
 # Run mutation tests
-vendor/bin/infection --initial-tests-php-options="-d zend_extension=xdebug.so" --threads=2 -s --min-msi=95 --min-covered-msi=95
-
-# Placeholder for extracting coverage metric
-echo "fa" > /tmp/reports/infection
+vendor/bin/infection --coverage=reports/infection --threads=2 -s --min-msi=95 --min-covered-msi=95

--- a/credentials.yaml.dist
+++ b/credentials.yaml.dist
@@ -2,3 +2,4 @@ docker-hub-email: foo
 docker-hub-user: foo
 docker-hub-password: foo
 github-access-token: foo
+codecov-token: foo

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,7 +21,8 @@
 
     <!-- Reports -->
     <logging>
-        <log type="coverage-html" target="reports/phpunit/coverage" lowUpperBound="85" highLowerBound="90" />
+        <log type="coverage-html" target="reports/phpunit" lowUpperBound="85" highLowerBound="90" />
+        <log type="coverage-clover" target="reports/phpunit/coverage.xml" lowUpperBound="85" highLowerBound="90" />
 
         <!-- For infection -->
         <log type="coverage-xml" target="reports/infection/coverage-xml"/>


### PR DESCRIPTION
  * Refactor ci test runner to run coverage on phpunit, generate clover xml, and reuse in infection
  * Integrate with Codecov:
    * Upload clover to codecov
    * Add app to github