### PR TITLE
Remove unnecessary rewind statement from request when handling kong errors

### DIFF
--- a/src/Kong/Handler.php
+++ b/src/Kong/Handler.php
@@ -127,9 +127,7 @@ class Handler
      */
     private function handleUnknownErrors(BadResponseException $ex, Certificate $certificate): void
     {
-        $request = $ex->getRequest();
-        $request->getBody()->rewind();
-
+        $request  = $ex->getRequest();
         $response = $ex->getResponse();
         $message  = $ex->getMessage();
 


### PR DESCRIPTION
As per title.