### PR TITLE
Tighten up code quality requirements for build pass status

### DIFF
--- a/concourse/tests.sh
+++ b/concourse/tests.sh
@@ -23,7 +23,7 @@ vendor/bin/phpstan -v analyse -l 7 src -c phpstan.neon  && printf "\n ${bold}PHP
 php -d zend_extension=xdebug.so vendor/bin/phpunit --testdox
 
 # Run mutation tests
-vendor/bin/infection --coverage=reports/infection --threads=2 -s --min-msi=95 --min-covered-msi=95
+vendor/bin/infection --coverage=reports/infection --threads=2 -s --min-msi=100 --min-covered-msi=100
 
 # Go back to initial working dir to allow outputs to function
 cd ${INITIAL_FOLDER}

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -14,6 +14,11 @@
     "mutators": {
         "@default": true,
         "IdenticalEqual": false,
-        "NotIdenticalNotEqual": false
+        "NotIdenticalNotEqual": false,
+        "FalseValue": {
+            "ignore": [
+                "PhpDockerIo\\KongCertbot\\Certbot\\Handler::acquireCertificate"
+            ]
+        }
     }
 }

--- a/src/Kong/Handler.php
+++ b/src/Kong/Handler.php
@@ -102,14 +102,13 @@ class Handler
         $responseCode     = $response !== null ? $response->getStatusCode() : null;
         $responseContents = $response !== null ? $response->getBody()->getContents() : '';
 
-        switch (true) {
-            case $response === null:
-                return false;
-
-            case $responseCode === 409:
+        switch ($responseCode) {
+            case 409:
                 return true;
 
-            case $responseCode === 400:
+            // In newer versions of Kong, a database primary key conflict error kinda leaks back in the response and
+            // with a 400 error code
+            case 400:
                 $decoded = json_decode($responseContents);
 
                 return \preg_match('/already associated with existing certificate/', $decoded->message ?? '') > 0;

--- a/src/Kong/Handler.php
+++ b/src/Kong/Handler.php
@@ -99,7 +99,7 @@ class Handler
     private function isConflict(BadResponseException $ex): bool
     {
         $response         = $ex->getResponse();
-        $responseCode     = $response !== null ? $response->getStatusCode() : false;
+        $responseCode     = $response !== null ? $response->getStatusCode() : null;
         $responseContents = $response !== null ? $response->getBody()->getContents() : '';
 
         switch (true) {


### PR DESCRIPTION
  * Tune up infection config to avoid a couple of false positives on certbot handler
  * Avoid a couple of other infection false positives by refactoring some code
  * Simplify kong cert conflict detection logic
  * Tighten up infection pass metrics on ci tests: require 100% coverage