### PR TITLE
Remove UPSERT workarounds

### DIFF
--- a/src/Kong/Handler.php
+++ b/src/Kong/Handler.php
@@ -51,31 +51,36 @@ class Handler
             ],
         ];
 
-        // Unfortunately for us, PUT is not UPSERT
+        // From Kong 0.14, they finally fixed PUT as UPSERT
+        // Any domain can be used on the endpoint, as they're aliased internally to the single
+        // certificate object within Kong
         try {
-            $this->guzzle->request('post', \sprintf('%s/certificates', $kongAdminUri), $payload);
+            $this->guzzle->request(
+                'put',
+                \sprintf('%s/certificates/%s', $kongAdminUri, $certificate->getDomains()[0]),
+                $payload
+            );
         } catch (BadResponseException $ex) {
-            // Update certificates only on conflict
-            if ($this->isConflict($ex) === false) {
-                $this->handleUnknownErrors($ex, $certificate);
+            $request  = $ex->getRequest();
+            $response = $ex->getResponse();
+            $message  = $ex->getMessage();
 
-                return false;
+            if ($response === null) {
+                $message = 'empty response';
             }
 
-            // Remove SNIs from PATCH as we will be patching into each domain individually
-            unset($payload['json']['snis']);
+            $responseCode = $ex->getResponse() !== null ? $ex->getResponse()->getStatusCode() : $ex->getCode();
 
-            foreach ($certificate->getDomains() as $domain) {
-                try {
-                    $this->guzzle->request(
-                        'patch',
-                        \sprintf('%s/certificates/%s', $kongAdminUri, $domain),
-                        $payload
-                    );
-                } catch (ClientException $patchException) {
-                    $this->errors[] = new Error($patchException->getCode(), [$domain], $patchException->getMessage());
-                }
-            }
+            $summary = \sprintf(
+                'Kong error %s: %s. Request method `%s`, headers %s, body %s',
+                $responseCode,
+                $message,
+                $request->getMethod(),
+                \json_encode($request->getHeaders()),
+                \json_encode($request->getBody()->getContents())
+            );
+
+            $this->errors[] = new Error($responseCode, $certificate->getDomains(), $summary);
         }
 
         return \count($this->errors) === 0;
@@ -87,64 +92,5 @@ class Handler
     public function getErrors(): array
     {
         return $this->errors;
-    }
-
-    /**
-     * Preexisting certificates can generate either a 409, or a 400 leaking from Kong's database with some stuff on it.
-     *
-     * @param BadResponseException $ex
-     *
-     * @return bool
-     */
-    private function isConflict(BadResponseException $ex): bool
-    {
-        $response         = $ex->getResponse();
-        $responseCode     = $response !== null ? $response->getStatusCode() : null;
-        $responseContents = $response !== null ? $response->getBody()->getContents() : '';
-
-        switch ($responseCode) {
-            case 409:
-                return true;
-
-            // In newer versions of Kong, a database primary key conflict error kinda leaks back in the response and
-            // with a 400 error code
-            case 400:
-                $decoded = json_decode($responseContents);
-
-                return \preg_match('/already associated with existing certificate/', $decoded->message ?? '') > 0;
-
-            default:
-                return false;
-        }
-    }
-
-    /**
-     * Parses an unhandled guzzle bad response exception into an error object and adds to the list
-     *
-     * @param BadResponseException $ex
-     * @param Certificate          $certificate
-     */
-    private function handleUnknownErrors(BadResponseException $ex, Certificate $certificate): void
-    {
-        $request  = $ex->getRequest();
-        $response = $ex->getResponse();
-        $message  = $ex->getMessage();
-
-        if ($response === null) {
-            $message = 'empty response';
-        }
-
-        $responseCode = $ex->getResponse() !== null ? $ex->getResponse()->getStatusCode() : $ex->getCode();
-
-        $summary = \sprintf(
-            'Kong error %s: %s. Request method `%s`, headers %s, body %s',
-            $responseCode,
-            $message,
-            $request->getMethod(),
-            \json_encode($request->getHeaders()),
-            \json_encode($request->getBody()->getContents())
-        );
-
-        $this->errors[] = new Error($responseCode, $certificate->getDomains(), $summary);
     }
 }

--- a/tests/Command/UpdateCertificatesCommandEndToEndTest.php
+++ b/tests/Command/UpdateCertificatesCommandEndToEndTest.php
@@ -62,7 +62,7 @@ class UpdateCertificatesCommandEndToEndTest extends TestCase
     {
         $email    = 'foo@bar.com';
         $domains  = self::MAIN_DOMAIN;
-        $endpoint = self::KONG_ENDPOINT . '/certificates';
+        $endpoint = self::KONG_ENDPOINT . '/certificates/' . self::MAIN_DOMAIN;
 
         $expectedCertbotCommand = sprintf(
             'certbot certonly  --agree-tos --standalone --preferred-challenges http -n -m %s --expand -d %s',
@@ -79,7 +79,7 @@ class UpdateCertificatesCommandEndToEndTest extends TestCase
         $this->httpClient
             ->expects(self::once())
             ->method('request')
-            ->with('post', $endpoint, self::callback(function (array $argument) {
+            ->with('put', $endpoint, self::callback(function (array $argument) {
                 self::assertArrayHasKey('json', $argument);
 
                 // Cert values match fixtures
@@ -115,7 +115,7 @@ class UpdateCertificatesCommandEndToEndTest extends TestCase
         $secondDomain = 'lalala.com';
         $email        = 'foo@bar.com';
         $domains      = self::MAIN_DOMAIN . ',' . $secondDomain;
-        $endpoint     = self::KONG_ENDPOINT . '/certificates';
+        $endpoint     = self::KONG_ENDPOINT . '/certificates/' . self::MAIN_DOMAIN;
 
         $expectedCertbotCommand = sprintf(
             'certbot certonly --test-cert --agree-tos --standalone --preferred-challenges http -n -m %s --expand -d %s -d %s',
@@ -133,7 +133,7 @@ class UpdateCertificatesCommandEndToEndTest extends TestCase
         $this->httpClient
             ->expects(self::once())
             ->method('request')
-            ->with('post', $endpoint, self::callback(function (array $argument) {
+            ->with('put', $endpoint, self::callback(function (array $argument) {
                 self::assertArrayHasKey('json', $argument);
 
                 // Cert values match fixtures

--- a/tests/Kong/HandlerTest.php
+++ b/tests/Kong/HandlerTest.php
@@ -42,20 +42,21 @@ class HandlerTest extends TestCase
      */
     public function storeSucceedsWithOneDomain(): void
     {
-        $certificate = new Certificate('foo', 'bar', ['foo.bar']);
+        $domain      = 'foo.bar';
+        $certificate = new Certificate('foo', 'bar', [$domain]);
 
         $response = $this->getMockBuilder(ResponseInterface::class)->getMock();
 
         $this->httpClient
             ->expects(self::once())
             ->method('request')
-            ->with('post', self::KONG_ADMIN_URI . '/certificates', [
-                'headers'     => [
+            ->with('put', self::KONG_ADMIN_URI . '/certificates/' . $domain, [
+                'headers' => [
                     'accept' => 'application/json',
                 ],
-                'json' => [
-                    'cert'   => 'foo',
-                    'key'    => 'bar',
+                'json'    => [
+                    'cert' => 'foo',
+                    'key'  => 'bar',
                     'snis' => ['foo.bar'],
                 ],
             ])
@@ -70,21 +71,22 @@ class HandlerTest extends TestCase
      */
     public function storeSucceedsWithMultipleDomains(): void
     {
-        $certificate = new Certificate('foo', 'bar', ['foo.bar', 'bar.foo', 'doom.bar']);
+        $domains     = ['foo.bar', 'bar.foo', 'doom.bar'];
+        $certificate = new Certificate('foo', 'bar', $domains);
 
         $response = $this->getMockBuilder(ResponseInterface::class)->getMock();
 
         $this->httpClient
             ->expects(self::once())
             ->method('request')
-            ->with('post', self::KONG_ADMIN_URI . '/certificates', [
-                'headers'     => [
+            ->with('put', self::KONG_ADMIN_URI . '/certificates/' . $domains[0], [
+                'headers' => [
                     'accept' => 'application/json',
                 ],
-                'json' => [
-                    'cert'   => 'foo',
-                    'key'    => 'bar',
-                    'snis' => ['foo.bar', 'bar.foo', 'doom.bar'],
+                'json'    => [
+                    'cert' => 'foo',
+                    'key'  => 'bar',
+                    'snis' => $domains,
                 ],
             ])
             ->willReturn($response);
@@ -99,11 +101,11 @@ class HandlerTest extends TestCase
      */
     public function storeHandlesUnknownKongError(int $statusCode): void
     {
-        $domains      = ['foo.bar', 'bar.foo', 'doom.bar'];
-        $certificate  = new Certificate('foo', 'bar', $domains);
+        $domains     = ['foo.bar', 'bar.foo', 'doom.bar'];
+        $certificate = new Certificate('foo', 'bar', $domains);
 
         $expectedErrorMessage = \sprintf(
-            'Kong error %s: foobar. Request method `post`, headers {"content-type":"application\/json"}, body "[\"foo\"]"',
+            'Kong error %s: foobar. Request method `put`, headers {"content-type":"application\/json"}, body "[\"foo\"]"',
             $statusCode
         );
 
@@ -150,9 +152,9 @@ class HandlerTest extends TestCase
             ->willReturn($headers);
 
         $request
-            ->expects(self::any())
+            ->expects(self::atLeast(1))
             ->method('getMethod')
-            ->willReturn('post');
+            ->willReturn('put');
 
         $exception = new ClientException($exceptionMessage, $request, $response);
 
@@ -182,11 +184,11 @@ class HandlerTest extends TestCase
      */
     public function storeHadlesKongEmptyResponse(): void
     {
-        $domains      = ['foo.bar', 'bar.foo', 'doom.bar'];
-        $certificate  = new Certificate('foo', 'bar', $domains);
+        $domains     = ['foo.bar', 'bar.foo', 'doom.bar'];
+        $certificate = new Certificate('foo', 'bar', $domains);
 
         $expectedErrorMessage = \sprintf(
-            'Kong error %s: empty response. Request method `post`, headers {"content-type":"application\/json"}, body "[\"foo\"]"',
+            'Kong error %s: empty response. Request method `put`, headers {"content-type":"application\/json"}, body "[\"foo\"]"',
             0
         );
 
@@ -218,7 +220,7 @@ class HandlerTest extends TestCase
         $request
             ->expects(self::any())
             ->method('getMethod')
-            ->willReturn('post');
+            ->willReturn('put');
 
         $exception = new ClientException($exceptionMessage, $request, null);
 
@@ -229,247 +231,6 @@ class HandlerTest extends TestCase
 
         $expectedErrors = [
             new Error(0, $domains, $expectedErrorMessage),
-        ];
-
-        self::assertFalse($this->handler->store($certificate, self::KONG_ADMIN_URI));
-        self::assertEquals($expectedErrors, $this->handler->getErrors());
-    }
-
-    /**
-     * @test
-     */
-    public function storeHandlesHttpConflictInOneDomain(): void
-    {
-        $certificate = new Certificate('foo', 'bar', ['foo.bar']);
-
-        $response  = $this->getMockBuilder(ResponseInterface::class)->getMock();
-        $body      = $this->getMockBuilder(StreamInterface::class)->getMock();
-        $exception = $this->getMockBuilder(ClientException::class)->disableOriginalConstructor()->getMock();
-
-        $this->httpClient
-            ->expects(self::at(0))
-            ->method('request')
-            ->with('post')
-            ->willThrowException($exception);
-
-        $this->httpClient
-            ->expects(self::at(1))
-            ->method('request')
-            ->with('patch', self::KONG_ADMIN_URI . '/certificates/foo.bar', [
-                'headers'     => [
-                    'accept' => 'application/json',
-                ],
-                'json' => [
-                    'cert' => 'foo',
-                    'key'  => 'bar',
-                ],
-            ])
-            ->willReturn($response);
-
-        $exception
-            ->expects(self::any())
-            ->method('getResponse')
-            ->willReturn($response);
-
-        $response
-            ->expects(self::any())
-            ->method('getBody')
-            ->willReturn($body);
-
-        $response
-            ->expects(self::any())
-            ->method('getStatusCode')
-            ->willReturn(409);
-
-        self::assertTrue($this->handler->store($certificate, self::KONG_ADMIN_URI));
-        self::assertEmpty($this->handler->getErrors());
-    }
-
-    /**
-     * @test
-     */
-    public function storeHandlesBadRequestConflictInOneDomain(): void
-    {
-        $certificate = new Certificate('foo', 'bar', ['foo.bar']);
-
-        $response  = $this->getMockBuilder(ResponseInterface::class)->getMock();
-        $body      = $this->getMockBuilder(StreamInterface::class)->getMock();
-        $exception = $this->getMockBuilder(ClientException::class)->disableOriginalConstructor()->getMock();
-
-        $this->httpClient
-            ->expects(self::at(0))
-            ->method('request')
-            ->with('post')
-            ->willThrowException($exception);
-
-        $this->httpClient
-            ->expects(self::at(1))
-            ->method('request')
-            ->with('patch', self::KONG_ADMIN_URI . '/certificates/foo.bar', [
-                'headers'     => [
-                    'accept' => 'application/json',
-                ],
-                'json' => [
-                    'cert' => 'foo',
-                    'key'  => 'bar',
-                ],
-            ])
-            ->willReturn($response);
-
-        $exception
-            ->expects(self::any())
-            ->method('getResponse')
-            ->willReturn($response);
-
-        $response
-            ->expects(self::any())
-            ->method('getStatusCode')
-            ->willReturn(400);
-
-        $response
-            ->expects(self::any())
-            ->method('getBody')
-            ->willReturn($body);
-
-        $body
-            ->expects(self::any())
-            ->method('rewind');
-
-        $json = <<<JSON
-{
-    "strategy": "postgres",
-    "message": "schema violation (snis: foo.bar already associated with existing certificate '9f62c9f4-f80c-11e8-8786-bb62c1494a3b')",
-    "name": "schema violation",
-    "fields": {
-        "snis": "foo.bar already associated with existing certificate '9f62c9f4-f80c-11e8-8786-bb62c1494a3b'"
-    },
-    "code": 2
-}
-JSON;
-
-        $body
-            ->expects(self::any())
-            ->method('getContents')
-            ->willReturn($json);
-
-        self::assertTrue($this->handler->store($certificate, self::KONG_ADMIN_URI));
-        self::assertEmpty($this->handler->getErrors());
-    }
-
-    /**
-     * @test
-     */
-    public function storeHandlesHttpConflictInSeveralDomains(): void
-    {
-        $domains     = ['foo.bar', 'bar.foo'];
-        $certificate = new Certificate('foo', 'bar', $domains);
-
-        $response  = $this->getMockBuilder(ResponseInterface::class)->getMock();
-        $body      = $this->getMockBuilder(StreamInterface::class)->getMock();
-        $exception = $this->getMockBuilder(ClientException::class)->disableOriginalConstructor()->getMock();
-
-        $this->httpClient
-            ->expects(self::at(0))
-            ->method('request')
-            ->with('post')
-            ->willThrowException($exception);
-
-        foreach ($domains as $key => $domain) {
-            $this->httpClient
-                ->expects(self::at($key + 1))
-                ->method('request')
-                ->with('patch', self::KONG_ADMIN_URI . '/certificates/' . $domain, [
-                    'headers'     => [
-                        'accept' => 'application/json',
-                    ],
-                    'json' => [
-                        'cert' => 'foo',
-                        'key'  => 'bar',
-                    ],
-                ])
-                ->willReturn($response);
-        }
-
-        $exception
-            ->expects(self::any())
-            ->method('getResponse')
-            ->willReturn($response);
-
-        $response
-            ->expects(self::any())
-            ->method('getStatusCode')
-            ->willReturn(409);
-
-        $response
-            ->expects(self::any())
-            ->method('getBody')
-            ->willReturn($body);
-
-        self::assertTrue($this->handler->store($certificate, self::KONG_ADMIN_URI));
-        self::assertEmpty($this->handler->getErrors());
-    }
-
-    /**
-     * @test
-     */
-    public function storeHandlesHttpExceptionOnPatch(): void
-    {
-        $domains     = ['foo.bar'];
-        $certificate = new Certificate('foo', 'bar', $domains);
-
-        $secondErrorStatus = 500;
-        $secondErrorMsg    = 'covfefe';
-
-        /** @var RequestInterface|MockObject $request */
-        $request = $this->getMockBuilder(RequestInterface::class)->getMock();
-
-        /** @var ResponseInterface|MockObject $response */
-        $response = $this->getMockBuilder(ResponseInterface::class)->getMock();
-
-        /** @var ResponseInterface|MockObject $response */
-        $secondResponse = $this->getMockBuilder(ResponseInterface::class)->getMock();
-
-        $exception = $this->getMockBuilder(ClientException::class)->disableOriginalConstructor()->getMock();
-
-        $body = $this->getMockBuilder(StreamInterface::class)->getMock();
-
-
-        $exception
-            ->expects(self::any())
-            ->method('getResponse')
-            ->willReturn($response);
-
-        $response
-            ->expects(self::any())
-            ->method('getStatusCode')
-            ->willReturn(409);
-
-        $response
-            ->expects(self::any())
-            ->method('getBody')
-            ->willReturn($body);
-
-        $secondResponse
-            ->expects(self::any())
-            ->method('getStatusCode')
-            ->willReturn($secondErrorStatus);
-
-        $this->httpClient
-            ->expects(self::at(0))
-            ->method('request')
-            ->with('post')
-            ->willThrowException($exception);
-
-        $anotherException = new ClientException($secondErrorMsg, $request, $secondResponse);
-
-        $this->httpClient
-            ->expects(self::at(1))
-            ->method('request')
-            ->with('patch')
-            ->willThrowException($anotherException);
-
-        $expectedErrors = [
-            new Error($secondErrorStatus, $domains, $secondErrorMsg),
         ];
 
         self::assertFalse($this->handler->store($certificate, self::KONG_ADMIN_URI));


### PR DESCRIPTION
Finally, Kong 0.14 correctly implements PUT as functional UPSERT for certs - this allows us to simplify our code enormously, as well as fix a bug whereby adding a new domain to a pre-existing list would throw an error.

Now adding or removing domains works correctly and we need tons less tests.